### PR TITLE
グループの編集機能の実装

### DIFF
--- a/app/assets/stylesheets/_chat-groups.scss
+++ b/app/assets/stylesheets/_chat-groups.scss
@@ -4,6 +4,16 @@
     padding: 0;
     color: $section-color;
     list-style: none;
+
+    .chat-group__link {
+      display: block;
+      color: #fff;
+
+      &:hover {
+        background-color: #384a62;
+      }
+    }
+
     .chat-group {
       padding: 20px 20px;
       color: $section-color;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,4 +1,9 @@
 class GroupsController < ApplicationController
+
+  def index
+    @groups = current_user.groups
+  end
+
   def new
     @groups = Group.new
   end
@@ -6,7 +11,6 @@ class GroupsController < ApplicationController
   def create
     @group = Group.new(create_params)
     @group.user_ids << current_user.id
-    binding.pry
     if @group.save
       flash[:notice] = 'チャットグループが作成されました。'
       redirect_to :root and return
@@ -17,14 +21,26 @@ class GroupsController < ApplicationController
   end
 
   def edit
-    @group = Group.find(params[:group_id])
+    @group = Group.find(params[:id])
   end
 
   def update
+    @group = Group.find(params[:id])
+    if @group.update(update_params)
+      flash[:notice] = 'チャットグループが更新されました'
+      redirect_to :root and return
+    else
+      flash[:alert] = "グループ名を入力してください。"
+      redirect_to edit_group_path and return
+    end
   end
 
   private
   def create_params
+    params.require(:group).permit(:name, { user_ids: [] })
+  end
+
+  def update_params
     params.require(:group).permit(:name, { user_ids: [] })
   end
 end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,4 +1,12 @@
 class TopController < ApplicationController
+
+  before_action :select_group, only: [ :index ]
+
   def index
+    @groups = current_user.groups
+  end
+
+  def select_group
+    @group = Group.find(params[:group_id])
   end
 end

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -3,24 +3,17 @@
   = form_for(@group) do |f|
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
-        = f.label :name, "グループ名" , class = "chat-group-form__label"
+        = f.label :name, "グループ名", class: "chat-group-form__label"
       .chat-group-form__field--right
-        = f.text_field :group_name, placeholder: "グループ名を入力してください", value: @group.group_name, class: "chat-group-form__input"
+        = f.text_field :name, placeholder: "グループ名を入力してください", id: "group_name" ,value: @group.name, class: "chat-group-form__input"
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
         = f.label "チャットメンバーを追加", class: "chat-group-form__label"
       .chat-group-form__field--right
-        .chat-group-form__search.clearfix
-          = f.text_field :user_id, placeholder: "追加したいユーザー名を入力してください", id: "user-search-field", class: "chat-group-form__input"
-        #user-search-result
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        = f.label "チャットメンバー", class: "chat-group-form__label"
-      .chat-group-form__field--right
         #chat-group-users
           #chat-group-user-22.chat-group-user.clearfix
-            = f.text_field :user_id, type: "hidden", value: "22"
-            %p.chat-group-user__name seo_kyohei
+            = f.collection_check_boxes(:user_ids, User.where.not(name: @group.users), :id, :name) do |t|
+              - t.label { t.check_box + t.text }
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
       .chat-group-form__field--right

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,0 +1,1 @@
+= render 'layouts/chat_side'

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -9,7 +9,6 @@
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
         = f.label "チャットメンバー", class: "chat-group-form__label"
-
       .chat-group-form__field--right
         #chat-group-users
           #chat-group-user-22.chat-group-user.clearfix

--- a/app/views/layouts/_chat_side.html.haml
+++ b/app/views/layouts/_chat_side.html.haml
@@ -10,8 +10,4 @@
   %ul.chat-groups
     - @groups.each do |group|
       %li.chat-group
-        = link_to group_top_index_path(group.id), class: 'chat-group__link'  do
-          %p.chat-group__name
-            = group.name
-          %p.chat-group__message
-            hello
+        = render partial: "layouts/chat_side_groups", locals: { group: group }

--- a/app/views/layouts/_chat_side.html.haml
+++ b/app/views/layouts/_chat_side.html.haml
@@ -1,0 +1,17 @@
+.chat-side
+  .chat-user.clearfix
+    %h5
+      = current_user.name
+    .chat-user__actions
+      = link_to new_group_path, class: "chat-user__action" do
+        %i.fa.fa-pencil-square-o
+      = link_to edit_user_registration_path, class: "chat-user__action" do
+        %i.fa.fa-cog
+  %ul.chat-groups
+    - @groups.each do |group|
+      %li.chat-group
+        = link_to group_top_index_path(group.id), class: 'chat-group__link'  do
+          %p.chat-group__name
+            = group.name
+          %p.chat-group__message
+            hello

--- a/app/views/layouts/_chat_side_groups.html.haml
+++ b/app/views/layouts/_chat_side_groups.html.haml
@@ -1,0 +1,5 @@
+= link_to group_top_index_path(group), class: 'chat-group__link'  do
+  %p.chat-group__name
+    = group.name
+  %p.chat-group__message
+    hello

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -1,26 +1,16 @@
 %body
   .chat
-    .chat-side
-      .chat-user.clearfix
-        %h5 seo
-        .chat-user__actions
-          = link_to new_group_path, class: "chat-user__action" do
-            %i.fa.fa-pencil-square-o
-          = link_to edit_user_registration_path, class: "chat-user__action" do
-            %i.fa.fa-cog
-      %ul.chat-groups
-        %li.chat-group
-          %p.chat-group__name sample
-          %p.chat-group__message Good boy work
+    = render 'layouts/chat_side'
     .chat-main
       .chat-header.clearfix
         .chat-header--left
-          %h2 sample
+          %h2
+            = @group.name
           %p.chat-header__users
             Menbers:
             %span.chat-header__user  kazuki
         .chat-header--right
-          %a.chat-header--right__edit-btn Edit
+          = link_to "Edit", edit_group_path(@group) ,class: "chat-header--right__edit-btn"
       .chat-body
         %ul.chat-messages
           %li.chat-message

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
-  root to: "top#index"
-  resources :groups, only: [:new, :edit, :create, :update]
+  root to: "groups#index"
+  resources :groups, only: [:new, :edit, :create, :update] do
+    resources :top
+  end
 end


### PR DESCRIPTION
#WHAT
グループ新規作成後のtopページのビューの追加。
グループの編集機能の実装を行った。

#WHY
グループ編集ページに移動できるようにするため。
グループの情報を更新できるようにするため。